### PR TITLE
Quick fix: removed the celery configurations to make it work with django

### DIFF
--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -44,16 +44,6 @@ new_contract("function", lambda x: hasattr(x, "__call__"))
 
 new_contract("redis", lambda x: isinstance(x, (redis.Redis, redis.StrictRedis)))
 
-try:
-    # Check whether a custom Celery configuration module named "snowplow_celery_config" exists
-    import snowplow_celery_config
-    app = Celery()
-    app.config_from_object(snowplow_celery_config)
-
-except ImportError:
-    # Otherwise configure Celery with default settings
-    app = Celery("Snowplow", broker="redis://guest@localhost//")
-
 
 class Emitter(object):
     """


### PR DESCRIPTION
You need to explicitly integrate Celery with Django
http://docs.celeryproject.org/en/latest/whatsnew-3.1.html#django-supported-out-of-the-box
